### PR TITLE
Navigate to contact on successful scan

### DIFF
--- a/Cordial/app/containers/qrcode-scanner-container.js
+++ b/Cordial/app/containers/qrcode-scanner-container.js
@@ -15,14 +15,14 @@ class QRCodeScannerContainer extends Component {
 
 
   onBarCodeReadAddToContacts(barcode) {
-    var compressedData = (barcode.data);
+    const compressedData = (barcode.data);
     const extractJSONObject = jsonpack.unpack(compressedData);
-    var id = extractJSONObject.id;
-    id = id.split('_').join('*');
-    Card.put(id, extractJSONObject);
+    const cardId = extractJSONObject.id;
+    Card.put(cardId, extractJSONObject);
     const u = User.me();
-    User.put(u.id, {...u, contacts: [...u.contacts, extractJSONObject.id]});
-    alert("Contact Added");
+    User.put(u.id, {...u, contacts: [...u.contacts, cardId]});
+    Actions.pop();
+    Actions.contact({id: cardId});
   }
 
   render() {


### PR DESCRIPTION
Fixes #63 

I've also switched out the alert with actually navigating to the contact that you just scanned.

Transforming the id of the card is no longer needed because this is done model-side now.