### PR TITLE
Adds links to fields

### DIFF
--- a/Cordial/app/components/auto-link-text.js
+++ b/Cordial/app/components/auto-link-text.js
@@ -1,0 +1,18 @@
+import React, {Component} from 'react';
+import Autolink from 'react-native-autolink';
+
+
+export default class AutoLinkText extends Component {
+	render() {
+		const {style, numberOfLines, children} = this.props;
+		return (
+			<Autolink
+				phone email
+				linkStyle={ [{ color: '#2980b9'}, style] }
+				style={style}
+				text={children}
+				numberOfLines={numberOfLines}
+			/>
+		);
+	}
+}

--- a/Cordial/app/containers/card-container.js
+++ b/Cordial/app/containers/card-container.js
@@ -10,6 +10,7 @@ import React, {Component} from 'react';
 import _ from 'lodash';
 import {Actions} from 'react-native-router-flux';
 
+import AutoLinkText from '../components/auto-link-text';
 import WithKeyboard from '../hoc/with-keyboard';
 import ConnectToModel from '../models/connect-to-model';
 import TouchableIcon, {Icon} from '../components/touchable-icon';
@@ -26,16 +27,18 @@ import {
 	FOOTER_HEIGHT
 } from '../consts/styles';
 
-const ReadOnlyField = (props) => (
-	<View style={props.style}>
-		<Text
-			style={props.textStyle}
-			numberOfLines={1}
-			ellipsizeMode='tail'
-		>{props.value}</Text>
-	</View>
-);
-
+class ReadOnlyField extends Component {
+	render() {
+		const {style, textStyle, value} = this.props;
+		return (
+			<View style={style}>
+				<AutoLinkText style={textStyle} numberOfLines={1}>
+					{value}
+				</AutoLinkText>
+			</View>
+		);
+	}
+}
 
 class EditableField extends Component {
 	constructor(props) {

--- a/Cordial/package.json
+++ b/Cordial/package.json
@@ -12,6 +12,7 @@
     "lodash": "^4.17.4",
     "react": "15.4.2",
     "react-native": "0.40.0",
+    "react-native-autolink": "1.0.0",
     "react-native-camera": "git+https://github.com/lwansbrough/react-native-camera.git",
     "react-native-communications": "^2.2.1",
     "react-native-linear-gradient": "^2.0.0",


### PR DESCRIPTION
Makes phone numbers, emails, urls all tappable.
A current limitation is that phone numbers must be formatted xxx-yyy-zzzz for this package to find them correctly, but this is a detail that can be worked out when making forms more skookum (@arafeek I think you mentioned wanting to do this)
Note that email links on android emulators don't work properly, though it does work on a real device.

