### PR TITLE
Adds new default splash screen route, also for loading screens

### DIFF
--- a/Cordial/app/components/splash-screen.js
+++ b/Cordial/app/components/splash-screen.js
@@ -36,11 +36,13 @@ export class Splash extends React.Component {
 export default class SplashScreen extends React.Component {
 	componentDidMount() {
 		const redirectOptions = {type: ActionConst.REPLACE};
-		if (User.me()) {
-			setTimeout(() => Actions.tabbar(redirectOptions), SPLASH_TIME);
-		} else {
-			setTimeout(() => Actions.welcome(redirectOptions), SPLASH_TIME);
-		}
+			setTimeout(() => {
+			if (User.me()) {
+				Actions.tabbar(redirectOptions);
+			} else {
+				Actions.welcome(redirectOptions);
+			}
+		}, SPLASH_TIME);
 	}
 	render() {
 		return <Splash/>;

--- a/Cordial/app/components/splash-screen.js
+++ b/Cordial/app/components/splash-screen.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, Image, StyleSheet } from 'react-native';
+import { Actions, ActionConst } from 'react-native-router-flux';
+import {User} from '../models/Model';
+
+const SPLASH_TIME = 500;
+
+const styles = StyleSheet.create({
+	logo: {
+		flexDirection: 'row',
+		alignSelf: 'center',
+		height: 70,
+		width: 250,
+	},
+	screen: {
+		flex: 1,
+		justifyContent: 'center'
+	}
+});
+
+
+
+export class Splash extends React.Component {
+	render() {
+		return (
+			<View style={styles.screen}>
+				<Image
+					source={require('../assets/img/cordial.png')}
+					style={styles.logo}
+				/>
+			</View>
+		);
+	}
+}
+
+export default class SplashScreen extends React.Component {
+	componentDidMount() {
+		const redirectOptions = {type: ActionConst.REPLACE};
+		if (User.me()) {
+			setTimeout(() => Actions.tabbar(redirectOptions), SPLASH_TIME);
+		} else {
+			setTimeout(() => Actions.welcome(redirectOptions), SPLASH_TIME);
+		}
+	}
+	render() {
+		return <Splash/>;
+	}
+}
+

--- a/Cordial/app/containers/profile-container.js
+++ b/Cordial/app/containers/profile-container.js
@@ -9,6 +9,7 @@ import {
 import ConnectToModel from '../models/connect-to-model';
 import {Card, User} from '../models/Model';
 import CardContainer from '../containers/card-container';
+import { Splash } from '../components/splash-screen';
 
 //import StatusBarBackground from '../components/statusbar-background';
 import {brightBlue, lightBlue} from '../consts/styles';
@@ -18,7 +19,7 @@ class ProfileContainer extends Component {
   render() {
     // TODO: This assumes user only has one card
     const cards = Card.myCards();
-    if (cards.length === 0) return <Text>Loading...</Text>;
+    if (cards.length === 0) return <Splash/>;
     return (
       <View style={{flex: 1}}>
         <CardContainer readOnly={false} id={_.sample(cards).id}/>

--- a/Cordial/app/containers/welcome-container.js
+++ b/Cordial/app/containers/welcome-container.js
@@ -22,6 +22,7 @@ import {
   DEVICE_USER_ID
 } from '../consts/strings';
 import RegisterForm from '../components/register-form';
+import { Splash } from '../components/splash-screen';
 
 import {User} from '../models/Model';
 
@@ -53,7 +54,7 @@ class WelcomeContainer extends Component {
   render() {
     const { state, actions } = this.props;
     if (state.auth.loading) {
-      return <Text> Loading ... </Text>
+      return <Splash/>;
     }
     return (
       <View style={styles.container}>

--- a/Cordial/app/routes/index.js
+++ b/Cordial/app/routes/index.js
@@ -16,6 +16,7 @@ import QRCodeScannerContainer from '../containers/qrcode-scanner-container';
 import WelcomeContainer from '../containers/welcome-container';
 import LoginContainer from '../containers/login-container';
 import CardEditorContainer from '../containers/card-editor-container';
+import SplashScreen from '../components/splash-screen';
 import FieldPicker from '../containers/field-picker';
 import { FOOTER_HEIGHT, paleBlue, brightBlue } from '../consts/styles';
 
@@ -30,11 +31,15 @@ const styles = StyleSheet.create({
 });
 const routes = Actions.create(
   <Scene key="root">
+    <Scene key="splash"
+      component={SplashScreen}
+      title='Splash Screen'
+      hideNavBar={true}
+      initial={true}/>
     <Scene key="welcome"
       component={WelcomeContainer}
       title="Welcome"
-      hideNavBar={true}
-      initial={true} />
+      hideNavBar={true}/>
     <Scene key="login"
       component={LoginContainer}
       hideNavBar={true} />


### PR DESCRIPTION
Fixes #13 

This replaces the welcome screen as a default route, flashing the Cordial logo for half a second before redirecting to either the login screen or your profile.

I also swapped out all of the "loading..." placeholders with the same splash asset.